### PR TITLE
SQLThread: Fixed infinite loop

### DIFF
--- a/src/cooldogedev/libSQL/thread/SQLThread.php
+++ b/src/cooldogedev/libSQL/thread/SQLThread.php
@@ -85,7 +85,6 @@ abstract class SQLThread extends Thread
         $this->synchronized(
             function (): void {
                 $this->setRunning(false);
-                $this->quit();
                 $this->notify();
             }
         );


### PR DESCRIPTION
### Steps to reproduce the issue
- Enable xdebug or recursionguard and start the server
- Execute the stop command to stop the server
- A recursive calling loop has been detected
### backtrace
```
stop
[09:19:57.187] [Server thread/INFO]: [CONSOLE: Stopping the server]
[09:19:57.188] [Server thread/INFO]: Disabling DevTools v1.15.0
[09:19:57.189] [Server thread/INFO]: Disabling DEVirion v1.2.8
[09:19:57.189] [Server thread/INFO]: Disabling TNTTag v0.0.4
[09:19:57.191] [Server thread/INFO]: Unloading world "world"
[09:19:57.918] [Server thread/INFO]: Stopping other threads

Fatal error: Uncaught Error: Reached maximum call depth of 256, aborting! in P:\game\test1\new\virions\libSQL_fork\src\cooldogedev\libSQL\thread\SQLThread.php:87
Stack trace:
#0 [internal function]: cooldogedev\libSQL\thread\SQLThread->cooldogedev\libSQL\thread\{closure}()
#1 P:\game\test1\new\virions\libSQL_fork\src\cooldogedev\libSQL\thread\SQLThread.php(90): Threaded->synchronized(Object(Closure))
#2 P:\game\test1\new\virions\libSQL_fork\src\cooldogedev\libSQL\thread\SQLThread.php(88): cooldogedev\libSQL\thread\SQLThread->quit()
...
#378 [internal function]: cooldogedev\libSQL\thread\SQLThread->cooldogedev\libSQL\thread\{closure}()
#379 P:\game\test1\new\virions\libSQL_fork\src\cooldogedev\libSQL\thread\SQLThread.php(90): Threaded->synchronized(Object(Closure))
#380 phar://P:/game/test1/new/PocketMine-MP.phar/src/thread/ThreadManager.php(84): cooldogedev\libSQL\thread\SQLThread->quit()
#381 phar://P:/game/test1/new/PocketMine-MP.phar/src/PocketMine.php(313): pocketmine\thread\ThreadManager->stopAll()
#382 phar://P:/game/test1/new/PocketMine-MP.phar/src/PocketMine.php(328): pocketmine\server()
#383 P:\game\test1\new\PocketMine-MP.phar(11): require('phar://P:/game/...')
#384 {main}
  thrown in P:\game\test1\new\virions\libSQL_fork\src\cooldogedev\libSQL\thread\SQLThread.php on line 87

Took too long to stop, server was killed forcefully!
```