### PR TITLE
Add virion v3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,13 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {}
+    "require": {
+        "pocketmine/pocketmine-mp": "^4.0.0"
+    },
+    "extra": {
+        "virion": {
+            "spec": "3.0",
+            "namespace-root": "cooldogedev\\libSQL"
+        }
+    }
 }


### PR DESCRIPTION
After merging this pull request, your users may use Virion 3.0 in their plugins by using `vcs` dependencies in their composer.json, but you could make their lives easier by completing these steps:

1. Tag each release with the `git tag` command or the [GitHub web UI](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
2. Submit your package on Packagist: <https://packagist.org/packages/submit>

Please follow these steps every time you release a new stable version so that user plugins can get their dependencies updated automatically upon the next build.